### PR TITLE
Style import form so it fits Sylius admin UI

### DIFF
--- a/src/Resources/views/Crud/import_form.html.twig
+++ b/src/Resources/views/Crud/import_form.html.twig
@@ -1,4 +1,15 @@
-{{ form_start(form, {'action': path('app_import_data', {'resource': resource}), 'method': 'POST'}) }}
-    {{ form_widget(form) }}
-    <input type="submit" value="Import data" />
-{{ form_end(form) }}
+{% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
+{% set header = 'sylius.ui.'~resource %}
+
+<div class="ui styled fluid accordion">
+    <div class="title active">
+        <i class="dropdown icon"></i>
+        {{ header|trans }} import
+    </div>
+    <div class="content active">
+        {{ form_start(form, {'action': path('app_import_data', {'resource': resource}), 'method': 'POST', 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
+        {{ form_widget(form) }}
+        <button class="ui button" type="submit">Import Data</button>
+        {{ form_end(form) }}
+    </div>
+</div>

--- a/tests/Behat/Page/ResourceIndexPage.php
+++ b/tests/Behat/Page/ResourceIndexPage.php
@@ -40,6 +40,6 @@ class ResourceIndexPage extends IndexPage implements ResourceIndexPageInterface
             ->selectOption($format)
         ;
 
-        $this->getDocument()->pressButton('Import data');
+        $this->getDocument()->pressButton('Import Data');
     }
 }


### PR DESCRIPTION
Applies some basic styling to the import form so it feels more naturally part of the Sylius admin UI.

Before:
![screen shot 2017-12-11 at 2 34 39 pm](https://user-images.githubusercontent.com/368545/33852551-9b93d698-de80-11e7-991e-591f0e4a70a5.png)

After:
![screen shot 2017-12-11 at 2 35 06 pm](https://user-images.githubusercontent.com/368545/33852554-a2f5f268-de80-11e7-9b74-fcc520041ecf.png)