### PR TITLE
Redirect to referer instead of building route programmatically

### DIFF
--- a/src/Controller/ImportDataController.php
+++ b/src/Controller/ImportDataController.php
@@ -84,8 +84,8 @@ final class ImportDataController
         if ($form->isSubmitted() && $form->isValid()) {
             $this->importData($importer, $form);
         }
-
-        return new RedirectResponse($request->headers->get('referer'));
+        $referer = (string) $request->headers->get('referer');
+        return new RedirectResponse($referer);
     }
 
     /**

--- a/src/Controller/ImportDataController.php
+++ b/src/Controller/ImportDataController.php
@@ -8,7 +8,6 @@ use FriendsOfSylius\SyliusImportExportPlugin\Form\ImportType;
 use FriendsOfSylius\SyliusImportExportPlugin\Importer\ImporterInterface;
 use FriendsOfSylius\SyliusImportExportPlugin\Importer\ImporterRegistry;
 use Sylius\Component\Registry\ServiceRegistry;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -79,7 +78,6 @@ final class ImportDataController
     public function importAction(Request $request): RedirectResponse
     {
         $importer = $request->attributes->get('resource');
-
         $form = $this->getForm();
         $form->handleRequest($request);
 
@@ -87,7 +85,7 @@ final class ImportDataController
             $this->importData($importer, $form);
         }
 
-        return new RedirectResponse($this->router->generate('sylius_admin_' . $importer . '_index'));
+        return new RedirectResponse($request->headers->get('referer'));
     }
 
     /**


### PR DESCRIPTION
If you are using the ImportExport Plugin for custom resources e.g. suppliers, the route names usually won't have the prefix `sylius_admin_` . So maybe it's better to redirect to the referer