### PR TITLE
Be more strict on exported field names - fields should exist

### DIFF
--- a/spec/Exporter/Plugin/PluginPoolSpec.php
+++ b/spec/Exporter/Plugin/PluginPoolSpec.php
@@ -51,6 +51,10 @@ class PluginPoolSpec extends ObjectBehavior
             'id2',
             'id3',
         ];
+
+        $plugin1->getFieldNames()->willReturn(['bla']);
+        $plugin2->getFieldNames()->willReturn(['test']);
+
         $plugin1->init($ids)->shouldBeCalled();
         $plugin2->init($ids)->shouldBeCalled();
         $this->initPlugins($ids);
@@ -77,6 +81,9 @@ class PluginPoolSpec extends ObjectBehavior
               ]
             );
 
+        $plugin1->getFieldNames()->willReturn(['description', 'name']);
+        $plugin2->getFieldNames()->willReturn(['description', 'name']);
+
         $this->getDataForId('id1')
             ->shouldReturn(
                 [
@@ -84,5 +91,23 @@ class PluginPoolSpec extends ObjectBehavior
                     'name' => 'testName',
                 ]
             );
+    }
+
+    function it_errors_if_not_all_keys_are_serviced(PluginInterface $plugin1)
+    {
+        $this->beConstructedWith([$plugin1], ['description', 'name', 'blabla']);
+
+        $plugin1->getFieldNames()->willReturn(['description', 'name']);
+
+        $plugin1
+            ->getData('id1', ['description', 'name', 'blabla'])
+            ->willReturn(
+                [
+                    'description' => '',
+                    'name' => 'testName',
+                ]
+            );
+
+        $this->shouldThrow(new \InvalidArgumentException('Not all defined export keys have been found: "blabla". Choose from: ""'))->during('getDataForId', ['id1']);
     }
 }

--- a/spec/Exporter/Plugin/ResourcePluginSpec.php
+++ b/spec/Exporter/Plugin/ResourcePluginSpec.php
@@ -45,11 +45,11 @@ class ResourcePluginSpec extends ObjectBehavior
         EntityManagerInterface $entityManager,
         ClassMetadata $classMetadata
     ) {
-        $idsToExport = [1, 2, 3];
+        $idsToExport = [1, 2];
 
         $repository->findBy(
             [
-                'id' => [1, 2, 3],
+                'id' => [1, 2],
             ]
         )->willReturn(
             [
@@ -138,7 +138,8 @@ class ResourcePluginSpec extends ObjectBehavior
                 'Description' => 'tax category for cars',
                 'Rates' => $carRates,
             ]);
-        $this->getData('3', ['Code', 'Name', 'Description', 'Rates'])
-            ->shouldReturn([]);
+
+        // Should error when unknown ID is asked
+        $this->shouldThrow()->during('getData', ['3', ['Code', 'Name', 'Description', 'Rates']]);
     }
 }

--- a/src/Exporter/Plugin/PluginFactory.php
+++ b/src/Exporter/Plugin/PluginFactory.php
@@ -6,10 +6,15 @@ namespace FriendsOfSylius\SyliusImportExportPlugin\Exporter\Plugin;
 
 class PluginFactory implements PluginFactoryInterface
 {
-    public function create(string $namespaceOfPlugin): PluginInterface
+    /**
+     * {@inheritdoc}
+     */
+    public function create(string $pluginNamespace): PluginInterface
     {
-        if (class_exists($namespaceOfPlugin)) {
-            return new $namespaceOfPlugin();
+        if (!class_exists($pluginNamespace)) {
+            throw new \InvalidArgumentException(sprintf('Class "%s" does not exist', $pluginNamespace));
         }
+
+        return new $pluginNamespace();
     }
 }

--- a/src/Exporter/Plugin/PluginFactoryInterface.php
+++ b/src/Exporter/Plugin/PluginFactoryInterface.php
@@ -6,5 +6,9 @@ namespace FriendsOfSylius\SyliusImportExportPlugin\Exporter\Plugin;
 
 interface PluginFactoryInterface
 {
-    public function create(string $namespaceOfPlugin): PluginInterface;
+    /**
+     * @param string $pluginNamespace
+     * @return PluginInterface
+     */
+    public function create(string $pluginNamespace): PluginInterface;
 }

--- a/src/Exporter/Plugin/PluginInterface.php
+++ b/src/Exporter/Plugin/PluginInterface.php
@@ -27,4 +27,9 @@ interface PluginInterface
      * @throws \UnexpectedValueException
      */
     public function init(array $idsToExport): void;
+
+    /**
+     * @return array
+     */
+    public function getFieldNames(): array;
 }

--- a/src/Exporter/Plugin/PluginPool.php
+++ b/src/Exporter/Plugin/PluginPool.php
@@ -9,20 +9,40 @@ namespace FriendsOfSylius\SyliusImportExportPlugin\Exporter\Plugin;
  */
 class PluginPool implements PluginPoolInterface
 {
-    /** @var PluginInterface[] */
+    /**
+     * @var PluginInterface[]
+     */
     private $plugins;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     private $exportKeys;
 
+    /**
+     * @var array
+     */
+    private $exportKeysNotFound;
+
+    /**
+     * @var array
+     */
+    private $exportKeysAvailable = [];
+
+    /**
+     * @param array $plugins
+     * @param array $exportKeys
+     */
     public function __construct(array $plugins, array $exportKeys)
     {
         $this->plugins = $plugins;
         $this->exportKeys = $exportKeys;
+
+        $this->exportKeysNotFound = $exportKeys;
     }
 
     /**
-     * @return PluginInterface[]
+     * @inheritdoc
      */
     public function getPlugins(): array
     {
@@ -30,25 +50,34 @@ class PluginPool implements PluginPoolInterface
     }
 
     /**
-     * @param array $ids
+     * @inheritdoc
      */
     public function initPlugins(array $ids): void
     {
         foreach ($this->plugins as $plugin) {
             $plugin->init($ids);
+
+            $this->exportKeysAvailable = array_merge($this->exportKeysAvailable, $plugin->getFieldNames());
         }
     }
 
     /**
-     * @param string $id
-     *
-     * @return array
+     * @inheritdoc
      */
     public function getDataForId(string $id): array
     {
         $result = [];
+
         foreach ($this->plugins as $index => $plugin) {
             $result = $this->getDataForIdFromPlugin($id, $plugin, $result);
+        }
+
+        if (!empty($this->exportKeysNotFound)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Not all defined export keys have been found: "%s". Choose from: "%s"',
+                implode(', ', $this->exportKeysNotFound),
+                implode(', ', $this->exportKeysAvailable)
+            ));
         }
 
         return $result;
@@ -67,6 +96,9 @@ class PluginPool implements PluginPoolInterface
             if (true === empty($result[$exportKey])) {
                 // no other plugin has delivered a value till now
                 $result[$exportKey] = $exportValue;
+
+                $foundKey = array_search($exportKey, $this->exportKeysNotFound);
+                unset($this->exportKeysNotFound[$foundKey]);
             }
         }
 

--- a/src/Exporter/Plugin/ResourcePlugin.php
+++ b/src/Exporter/Plugin/ResourcePlugin.php
@@ -12,24 +12,32 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 class ResourcePlugin implements ResourcePluginInterface
 {
-    /** @var array */
-    protected $fieldNames;
+    /**
+     * @var array
+     */
+    protected $fieldNames = [];
 
-    /** @var RepositoryInterface */
+    /**
+     * @var RepositoryInterface
+     */
     private $repository;
 
-    /** @var PropertyAccessorInterface */
+    /**
+     * @var PropertyAccessorInterface
+     */
     private $propertyAccessor;
 
-    /** @var EntityManagerInterface */
+    /**
+     * @var EntityManagerInterface
+     */
     private $entityManager;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     private $data;
 
     /**
-     * ResourcePlugin constructor.
-     *
      * @param RepositoryInterface $repository
      * @param PropertyAccessorInterface $propertyAccessor
      * @param EntityManagerInterface $entityManager
@@ -50,15 +58,15 @@ class ResourcePlugin implements ResourcePluginInterface
     public function getData(string $id, array $keysToExport): array
     {
         if (!isset($this->data[$id])) {
-            return [];
+            throw new \InvalidArgumentException(sprintf('Requested ID "%s", but it does not exist', $id));
         }
+
         $result = [];
+
         foreach ($keysToExport as $exportKey) {
-            $dataForExportKey = '';
             if ($this->hasPluginDataForExportKey($id, $exportKey)) {
-                $dataForExportKey = $this->getDataForExportKey($id, $exportKey);
+                $result[$exportKey] = $this->getDataForExportKey($id, $exportKey);
             }
-            $result[$exportKey] = $dataForExportKey;
         }
 
         return $result;
@@ -70,6 +78,7 @@ class ResourcePlugin implements ResourcePluginInterface
     public function init(array $idsToExport): void
     {
         $resources = $this->repository->findBy(['id' => $idsToExport]);
+
         foreach ($resources as $resource) {
             /** @var ResourceInterface $resource */
             $this->addDataForId($resource);
@@ -94,8 +103,10 @@ class ResourcePlugin implements ResourcePluginInterface
     private function addDataForId(ResourceInterface $resource): void
     {
         $fields = $this->entityManager->getClassMetadata(\get_class($resource));
+
         foreach ($fields->getColumnNames() as $index => $field) {
-            $this->fieldNames[$index] = $field;
+            $this->fieldNames[$index] = ucfirst($field);
+
             if ($this->propertyAccessor->isReadable($resource, $field)) {
                 $this->data[$resource->getId()][ucfirst($field)] = $this->propertyAccessor->getValue($resource, $field);
             }

--- a/src/Exporter/Plugin/ResourcePluginInterface.php
+++ b/src/Exporter/Plugin/ResourcePluginInterface.php
@@ -6,8 +6,4 @@ namespace FriendsOfSylius\SyliusImportExportPlugin\Exporter\Plugin;
 
 interface ResourcePluginInterface extends PluginInterface
 {
-    /**
-     * @return array
-     */
-    public function getFieldNames(): array;
 }

--- a/src/Exporter/ResourceExporter.php
+++ b/src/Exporter/ResourceExporter.php
@@ -62,6 +62,7 @@ class ResourceExporter implements ResourceExporterInterface
     {
         $this->pluginPool->initPlugins($idsToExport);
         $this->writer->write($this->resourceKeys);
+
         foreach ($idsToExport as $id) {
             $this->writeDataForId((string) $id);
         }


### PR DESCRIPTION
Use case: I created an Order export, with a field name that didn't exist at all (OrderNumber, it should be Number), which just resulted in an empty column in the export file. This change checks more strict whether the defines keys are actually being filled in order to avoid unexpected behavior.