### PR TITLE
Use php temp stream as default for exporting (closes #89)

### DIFF
--- a/src/Controller/ExportDataController.php
+++ b/src/Controller/ExportDataController.php
@@ -35,19 +35,19 @@ final class ExportDataController extends Controller
      */
     public function exportAction(string $resource, string $format): Response
     {
-        $filename = sprintf('%s-%s.%s', $resource, date('Y-m-d'), $format); // @todo Create a service for this
+        $outputFilename = sprintf('%s-%s.%s', $resource, date('Y-m-d'), $format); // @todo Create a service for this
 
-        return $this->exportData($resource, $format, $filename);
+        return $this->exportData($resource, $format, $outputFilename);
     }
 
     /**
      * @param string $exporter
      * @param string $format
-     * @param string $filename
+     * @param string $outputFilename
      *
      * @return Response
      */
-    private function exportData(string $exporter, string $format, string $filename): Response
+    private function exportData(string $exporter, string $format, string $outputFilename): Response
     {
         $name = ExporterRegistry::buildServiceName($exporter, $format);
 
@@ -61,7 +61,6 @@ final class ExportDataController extends Controller
         /** @var \Sylius\Component\Resource\Repository\RepositoryInterface $repository */
         $repository = $this->get('sylius.repository.' . $exporter);
 
-        $service->setExportFile($filename);
         $allItems = $repository->findAll();
         $idsToExport = [];
         foreach ($allItems as $item) {
@@ -70,13 +69,11 @@ final class ExportDataController extends Controller
         }
         $service->export($idsToExport);
 
-        $exportedData = $service->getExportedData($filename);
-
-        $response = new Response($exportedData);
+        $response = new Response($service->getExportedData());
 
         $disposition = $response->headers->makeDisposition(
             ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-            $filename
+            $outputFilename
         );
 
         $response->headers->set('Content-Disposition', $disposition);

--- a/src/Exporter/ResourceExporter.php
+++ b/src/Exporter/ResourceExporter.php
@@ -62,9 +62,9 @@ class ResourceExporter implements ResourceExporterInterface
     /**
      * {@inheritdoc}
      */
-    public function getExportedData(string $filename): string
+    public function getExportedData(): string
     {
-        return $this->writer->getFileContent($filename);
+        return $this->writer->getFileContent();
     }
 
     /**

--- a/src/Exporter/ResourceExporterInterface.php
+++ b/src/Exporter/ResourceExporterInterface.php
@@ -17,9 +17,7 @@ interface ResourceExporterInterface
     public function setExportFile(string $filename): void;
 
     /**
-     * @param string $filename
-     *
      * @return string
      */
-    public function getExportedData(string $filename): string;
+    public function getExportedData(): string;
 }

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -40,10 +40,15 @@ class CsvWriter implements WriterInterface
     /**
      * {@inheritdoc}
      */
-    public function getFileContent(string $filename): string
+    public function getFileContent(): string
     {
+        $this->writer->setCloseStreamOnFinish(true);
+
+        rewind($this->writer->getStream());
+        $contents = stream_get_contents($this->writer->getStream());
+
         $this->writer->finish();
 
-        return file_get_contents($filename);
+        return $contents;
     }
 }

--- a/src/Writer/WriterInterface.php
+++ b/src/Writer/WriterInterface.php
@@ -17,9 +17,7 @@ interface WriterInterface
     public function setFile(string $filename): void;
 
     /**
-     * @param string $filename
-     *
      * @return string
      */
-    public function getFileContent(string $filename): string;
+    public function getFileContent(): string;
 }


### PR DESCRIPTION
When not setting a filename for the `CsvWriter` a `php://temp` stream is being used, which is being emptied at the end of the request or when not needed anymore. This allows us to even simplify fetching of the data regardless of whether a filename has been set, because the stream is available. Still allows for customisation.