### PR TITLE
CLI export fix

### DIFF
--- a/src/Command/ExportDataCommand.php
+++ b/src/Command/ExportDataCommand.php
@@ -65,7 +65,7 @@ final class ExportDataCommand extends Command
             $this->listExporters($input, $output, $message);
         }
         $format = $input->getOption('format');
-        $name = ExporterRegistry::buildServiceName(('sylius.' . $exporter), $format);
+        $name = ExporterRegistry::buildServiceName('sylius.' . $exporter, $format);
 
         if (!$this->exporterRegistry->has($name)) {
             $message = sprintf(

--- a/src/Command/ExportDataCommand.php
+++ b/src/Command/ExportDataCommand.php
@@ -116,13 +116,16 @@ final class ExportDataCommand extends Command
         $output->writeln('<info>Available exporters:</info>');
         $all = array_keys($this->exporterRegistry->all());
         $exporters = [];
+        // "sylius.country.csv" is an example of an exporter
         foreach ($all as $exporter) {
             $exporter = explode('.', $exporter);
+            // saves the exporter in the exporters array, sets the exporterentity as the first key of the 2d array and the exportertypes each in the second array
             $exporters[$exporter[1]][] = $exporter[2];
         }
 
         $list = [];
         foreach ($exporters as $exporter => $formats) {
+            // prints the exporterentity, implodes the types and outputs them in a form
             $list[] = sprintf(
                 '%s (formats: %s)',
                 $exporter,

--- a/src/Command/ExportDataCommand.php
+++ b/src/Command/ExportDataCommand.php
@@ -65,7 +65,7 @@ final class ExportDataCommand extends Command
             $this->listExporters($input, $output, $message);
         }
         $format = $input->getOption('format');
-        $name = ExporterRegistry::buildServiceName($exporter, $format);
+        $name = ExporterRegistry::buildServiceName(('sylius.' . $exporter), $format);
 
         if (!$this->exporterRegistry->has($name)) {
             $message = sprintf(
@@ -118,7 +118,7 @@ final class ExportDataCommand extends Command
         $exporters = [];
         foreach ($all as $exporter) {
             $exporter = explode('.', $exporter);
-            $exporters[$exporter[0]][] = $exporter[1];
+            $exporters[$exporter[1]][] = $exporter[2];
         }
 
         $list = [];


### PR DESCRIPTION
- Added concatenation of 'sylius.' with the exporter as the exporter got renamed and needs a sylius infront now.

- Since the exporter has sylius infront now we have to ignore the first field of $exporter[]