### PR TITLE
Message queue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ admin overview panel using the event hook system, ie. `admin/tax-categories/`.
     ```bash
     $ bin/console sylius:export country my/countries/export/csv/file.csv --format=csv
     ```
+    
+  - Export data of resources to message queue using `country` exporter
+    ```bash
+    $ bin/console sylius:export-to-message-queue country
+    ```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ admin overview panel using the event hook system, ie. `admin/tax-categories/`.
     ```bash
     $ bin/console sylius:import tax_category my/tax/categories/csv/file.csv --format=csv
     ```
+  
+  - Import from message queue using the `country` importer
+  
+      ```bash
+      $ bin/console sylius:import-from-message-queue country
+      ```
    
   - Export data of resources to file using `country` exporter
     ```bash

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
     "suggest": {
         "portphp/excel": "To support importing excel files, use version ^1.1",
         "ext-zip": "To support writing of Excel files",
-        "portphp/csv": "To support importing csv files, use version ^1.1"
+        "portphp/csv": "To support importing csv files, use version ^1.1",
+        "enqueue/enqueue-bundle" : "To support message queuing",
+        "enqueue/redis" : "To support message queuing",
+        "predis/predis" : "To support message queuing"
     },
     "require-dev": {
         "portphp/excel": "^1.1.0",
@@ -35,7 +38,10 @@
         "phpunit/phpunit": "^5.6",
         "se/selenium-server-standalone": "^2.52",
         "sylius-labs/coding-standard": "^1.0",
-        "symplify/easy-coding-standard": "^2.4"
+        "symplify/easy-coding-standard": "^2.4",
+        "enqueue/enqueue-bundle": "^0.8.31",
+        "enqueue/redis": "^0.8.23",
+        "predis/predis": "^1.1"
     },
     "prefer-stable": true,
     "minimum-stability": "alpha",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97b2aa2e715234580641071edf46873b",
+    "content-hash": "dec9fe435b846ebf1c2770e0cf8e53e9",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -7418,6 +7418,334 @@
             "time": "2017-02-14T19:40:03+00:00"
         },
         {
+            "name": "enqueue/async-event-dispatcher",
+            "version": "0.8.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-enqueue/async-event-dispatcher.git",
+                "reference": "36902adf96e01a4db2311fd7896b9e5c96ed29de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-enqueue/async-event-dispatcher/zipball/36902adf96e01a4db2311fd7896b9e5c96ed29de",
+                "reference": "36902adf96e01a4db2311fd7896b9e5c96ed29de",
+                "shasum": ""
+            },
+            "require": {
+                "enqueue/enqueue": "^0.8@dev",
+                "php": ">=5.6",
+                "symfony/event-dispatcher": "^2.8|^3|^4"
+            },
+            "require-dev": {
+                "enqueue/fs": "^0.8@dev",
+                "enqueue/null": "^0.8@dev",
+                "enqueue/test": "^0.8@dev",
+                "phpunit/phpunit": "~5.5",
+                "symfony/config": "^2.8|^3|^4",
+                "symfony/dependency-injection": "^2.8|^3|^4",
+                "symfony/filesystem": "^2.8|^3|^4",
+                "symfony/http-kernel": "^2.8|^3|^4"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "^2.8|^3|^4 If you'd like to use async event dispatcher container extension."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Enqueue\\AsyncEventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Symfony async event dispatcher",
+            "homepage": "https://enqueue.forma-pro.com/",
+            "keywords": [
+                "async event",
+                "event dispatcher",
+                "messaging",
+                "queue"
+            ],
+            "time": "2018-03-23T10:52:55+00:00"
+        },
+        {
+            "name": "enqueue/enqueue",
+            "version": "0.8.29",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-enqueue/enqueue.git",
+                "reference": "d637e699d15b5343daa5c16d3b5b3641bc502c0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-enqueue/enqueue/zipball/d637e699d15b5343daa5c16d3b5b3641bc502c0b",
+                "reference": "d637e699d15b5343daa5c16d3b5b3641bc502c0b",
+                "shasum": ""
+            },
+            "require": {
+                "enqueue/null": "^0.8@dev",
+                "php": ">=5.6",
+                "psr/log": "^1",
+                "queue-interop/queue-interop": "^0.6@dev|^1.0.0-alpha1",
+                "ramsey/uuid": "^2|^3.5"
+            },
+            "require-dev": {
+                "empi89/php-amqp-stubs": "*@dev",
+                "enqueue/amqp-bunny": "^0.8@dev",
+                "enqueue/amqp-ext": "^0.8@dev",
+                "enqueue/amqp-lib": "^0.8@dev",
+                "enqueue/dbal": "^0.8@dev",
+                "enqueue/fs": "^0.8@dev",
+                "enqueue/gearman": "^0.8@dev",
+                "enqueue/gps": "^0.8@dev",
+                "enqueue/mongodb": "^0.8@dev",
+                "enqueue/pheanstalk": "^0.8@dev",
+                "enqueue/rdkafka": "^0.8@dev",
+                "enqueue/redis": "^0.8@dev",
+                "enqueue/simple-client": "^0.8@dev",
+                "enqueue/sqs": "^0.8@dev",
+                "enqueue/stomp": "^0.8@dev",
+                "enqueue/test": "^0.8@dev",
+                "phpunit/phpunit": "~5.5",
+                "symfony/config": "^2.8|^3|^4",
+                "symfony/console": "^2.8|^3|^4",
+                "symfony/dependency-injection": "^2.8|^3|^4",
+                "symfony/event-dispatcher": "^2.8|^3|^4",
+                "symfony/http-kernel": "^2.8|^3|^4"
+            },
+            "suggest": {
+                "enqueue/amqp-ext": "AMQP transport (based on php extension)",
+                "enqueue/dbal": "Doctrine DBAL transport",
+                "enqueue/fs": "Filesystem transport",
+                "enqueue/redis": "Redis transport",
+                "enqueue/sqs": "Amazon AWS SQS transport",
+                "enqueue/stomp": "STOMP transport",
+                "symfony/config": "^2.8|^3|^4",
+                "symfony/console": "^2.8|^3|^4 If you want to use li commands",
+                "symfony/dependency-injection": "^2.8|^3|^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Enqueue\\": ""
+                },
+                "files": [
+                    "functions_include.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Message Queue Library",
+            "homepage": "https://enqueue.forma-pro.com/",
+            "keywords": [
+                "AMQP",
+                "messaging",
+                "queue",
+                "rabbitmq"
+            ],
+            "time": "2018-05-04T05:47:00+00:00"
+        },
+        {
+            "name": "enqueue/enqueue-bundle",
+            "version": "0.8.31",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-enqueue/enqueue-bundle.git",
+                "reference": "5d57224edb468731ab1d40e4eba8a07df444ea58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-enqueue/enqueue-bundle/zipball/5d57224edb468731ab1d40e4eba8a07df444ea58",
+                "reference": "5d57224edb468731ab1d40e4eba8a07df444ea58",
+                "shasum": ""
+            },
+            "require": {
+                "enqueue/async-event-dispatcher": "^0.8@dev",
+                "enqueue/enqueue": "^0.8@dev",
+                "enqueue/null": "^0.8@dev",
+                "php": ">=5.6",
+                "symfony/framework-bundle": "^2.8|^3|^4"
+            },
+            "require-dev": {
+                "doctrine/doctrine-bundle": "~1.2",
+                "enqueue/amqp-bunny": "^0.8@dev",
+                "enqueue/amqp-ext": "^0.8@dev",
+                "enqueue/amqp-lib": "^0.8@dev",
+                "enqueue/dbal": "^0.8@dev",
+                "enqueue/fs": "^0.8@dev",
+                "enqueue/gps": "^0.8@dev",
+                "enqueue/job-queue": "^0.8@dev",
+                "enqueue/redis": "^0.8@dev",
+                "enqueue/sqs": "^0.8@dev",
+                "enqueue/stomp": "^0.8@dev",
+                "enqueue/test": "^0.8@dev",
+                "php-amqplib/php-amqplib": "^2.7@dev",
+                "phpunit/phpunit": "~5.5",
+                "symfony/browser-kit": "^2.8|^3|^4",
+                "symfony/expression-language": "^2.8|^3|^4",
+                "symfony/monolog-bundle": "^2.8|^3|^4"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Enqueue\\Bundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Message Queue Bundle",
+            "homepage": "https://enqueue.forma-pro.com/",
+            "keywords": [
+                "AMQP",
+                "messaging",
+                "queue",
+                "rabbitmq"
+            ],
+            "time": "2018-05-10T13:40:08+00:00"
+        },
+        {
+            "name": "enqueue/null",
+            "version": "0.8.24",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-enqueue/null.git",
+                "reference": "e75270a99e6d65a2b7d739fa6c6131338d85acee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-enqueue/null/zipball/e75270a99e6d65a2b7d739fa6c6131338d85acee",
+                "reference": "e75270a99e6d65a2b7d739fa6c6131338d85acee",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "queue-interop/queue-interop": "^0.6@dev|^1.0.0-alpha1"
+            },
+            "require-dev": {
+                "enqueue/enqueue": "^0.8@dev",
+                "enqueue/test": "^0.8@dev",
+                "phpunit/phpunit": "~5.5",
+                "queue-interop/queue-spec": "^0.5.3@dev",
+                "symfony/config": "^2.8|^3|^4",
+                "symfony/dependency-injection": "^2.8|^3|^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Enqueue\\Null\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Enqueue Null transport",
+            "homepage": "https://enqueue.forma-pro.com/",
+            "keywords": [
+                "messaging",
+                "queue",
+                "testing"
+            ],
+            "time": "2018-03-23T10:52:55+00:00"
+        },
+        {
+            "name": "enqueue/redis",
+            "version": "0.8.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-enqueue/redis.git",
+                "reference": "f453d7a2af54ec2edfe66dd05427ca4f295efefb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-enqueue/redis/zipball/f453d7a2af54ec2edfe66dd05427ca4f295efefb",
+                "reference": "f453d7a2af54ec2edfe66dd05427ca4f295efefb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "queue-interop/queue-interop": "^0.6@dev|^1.0.0-alpha1"
+            },
+            "require-dev": {
+                "enqueue/enqueue": "^0.8@dev",
+                "enqueue/null": "^0.8@dev",
+                "enqueue/test": "^0.8@dev",
+                "phpunit/phpunit": "~5.4.0",
+                "predis/predis": "^1.1",
+                "queue-interop/queue-spec": "^0.5.3@dev",
+                "symfony/config": "^2.8|^3|^4",
+                "symfony/dependency-injection": "^2.8|^3|^4"
+            },
+            "suggest": {
+                "enqueue/enqueue": "If you'd like to use advanced features like Client abstract layer or Symfony integration features",
+                "ext-redis": "Either this PHP extension or predis/predis extension has to be installed.",
+                "predis/predis": "Either this PHP library or redis extension has to be installed."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Enqueue\\Redis\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Message Queue Redis Transport",
+            "homepage": "https://enqueue.forma-pro.com/",
+            "keywords": [
+                "messaging",
+                "queue",
+                "redis"
+            ],
+            "time": "2018-03-06T10:46:03+00:00"
+        },
+        {
             "name": "friends-of-behat/context-service-extension",
             "version": "v1.2.0",
             "source": {
@@ -9593,6 +9921,99 @@
             "description": "Excel reader and writer for Port",
             "homepage": "https://github.com/portphp",
             "time": "2017-11-04T13:36:22+00:00"
+        },
+        {
+            "name": "predis/predis",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nrk/predis.git",
+                "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nrk/predis/zipball/f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "suggest": {
+                "ext-curl": "Allows access to Webdis when paired with phpiredis",
+                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Predis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniele Alessandri",
+                    "email": "suppakilla@gmail.com",
+                    "homepage": "http://clorophilla.net"
+                }
+            ],
+            "description": "Flexible and feature-complete Redis client for PHP and HHVM",
+            "homepage": "http://github.com/nrk/predis",
+            "keywords": [
+                "nosql",
+                "predis",
+                "redis"
+            ],
+            "time": "2016-06-16T16:22:20+00:00"
+        },
+        {
+            "name": "queue-interop/queue-interop",
+            "version": "0.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/queue-interop/queue-interop.git",
+                "reference": "38579005c0492c0275bbae31170edf30a7e740fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/queue-interop/queue-interop/zipball/38579005c0492c0275bbae31170edf30a7e740fa",
+                "reference": "38579005c0492c0275bbae31170edf30a7e740fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Queue\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of MQs objects. Based on Java JMS",
+            "homepage": "https://github.com/queue-interop/queue-interop",
+            "keywords": [
+                "MQ",
+                "jms",
+                "message queue",
+                "messaging",
+                "queue"
+            ],
+            "time": "2017-08-10T11:24:15+00:00"
         },
         {
             "name": "se/selenium-server-standalone",

--- a/composer.lock
+++ b/composer.lock
@@ -3556,16 +3556,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.12",
+            "version": "v2.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "258c89a6b97de7dfaf5b8c7607d0478e236b04fb"
+                "reference": "10bcb46e8f3d365170f6de9d05245aa066b81f09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/258c89a6b97de7dfaf5b8c7607d0478e236b04fb",
-                "reference": "258c89a6b97de7dfaf5b8c7607d0478e236b04fb",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/10bcb46e8f3d365170f6de9d05245aa066b81f09",
+                "reference": "10bcb46e8f3d365170f6de9d05245aa066b81f09",
                 "shasum": ""
             },
             "require": {
@@ -3597,10 +3597,11 @@
             "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
             "keywords": [
                 "csprng",
+                "polyfill",
                 "pseudorandom",
                 "random"
             ],
-            "time": "2018-04-04T21:24:14+00:00"
+            "time": "2018-06-08T15:26:40+00:00"
         },
         {
             "name": "payum/iso4217",

--- a/src/Command/ExportDataToMessageQueueCommand.php
+++ b/src/Command/ExportDataToMessageQueueCommand.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace FriendsOfSylius\SyliusImportExportPlugin\Command;
 
+use Enqueue\Redis\RedisConnectionFactory;
 use FriendsOfSylius\SyliusImportExportPlugin\Exporter\ExporterRegistry;
+use FriendsOfSylius\SyliusImportExportPlugin\Exporter\MqItemWriter;
 use FriendsOfSylius\SyliusImportExportPlugin\Exporter\ResourceExporterInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-final class ExportDataCommand extends Command
+final class ExportDataToMessageQueueCommand extends Command
 {
     use ContainerAwareTrait;
 
@@ -41,15 +42,10 @@ final class ExportDataCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('sylius:export')
-            ->setDescription('Export data to a file.')
+            ->setName('sylius:export-to-message-queue')
+            ->setDescription('Export data to message queue')
             ->setDefinition([
-                new InputArgument('exporter', InputArgument::OPTIONAL, 'The exporter to use.'),
-                new InputArgument('file', InputArgument::OPTIONAL, 'The target file to export to.'),
-                new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The format of the file to export to'),
-                /** @todo Extracting details to show with this option. At the moment it will have no effect */
-                new InputOption('details', null, InputOption::VALUE_NONE,
-                    'If to return details about skipped/failed rows'),
+                new InputArgument('exporter', InputArgument::OPTIONAL, 'The exporter to uses.'),
             ]);
     }
 
@@ -64,8 +60,15 @@ final class ExportDataCommand extends Command
             $message = 'choose an exporter';
             $this->listExporters($input, $output, $message);
         }
-        $format = $input->getOption('format');
-        $name = ExporterRegistry::buildServiceName('sylius.' . $exporter, $format);
+
+        /** @var RepositoryInterface $repository */
+        $repository = $this->container->get('sylius.repository.' . $exporter);
+        $allItems = $repository->findAll();
+
+        /** @var array $idsToExport */
+        $idsToExport = $this->prepareExport($allItems);
+
+        $name = ExporterRegistry::buildServiceName('sylius.' . $exporter, 'json');
 
         if (!$this->exporterRegistry->has($name)) {
             $message = sprintf(
@@ -76,32 +79,8 @@ final class ExportDataCommand extends Command
             $this->listExporters($input, $output, $message);
         }
 
-        $file = $input->getArgument('file');
-
-        /** @var RepositoryInterface $repository */
-        $repository = $this->container->get('sylius.repository.' . $exporter);
-        $allItems = $repository->findAll();
-        $idsToExport = [];
-        foreach ($allItems as $item) {
-            /** @var ResourceInterface $item */
-            $idsToExport[] = $item->getId();
-        }
-
-        /** @var ResourceExporterInterface $service */
-        $service = $this->exporterRegistry->get($name);
-        $service->setExportFile($file);
-
-        $service->export($idsToExport);
-
-        $service->finish();
-
-        $message = sprintf(
-            "<info>Exported %d item(s) to '%s' via the %s exporter</info>",
-            count($allItems),
-            $file,
-            $name
-        );
-        $output->writeln($message);
+        $this->export($name, $idsToExport, $exporter);
+        $this->finishExport($allItems, 'message queue', $name, $output);
     }
 
     /**
@@ -126,17 +105,66 @@ final class ExportDataCommand extends Command
         }
 
         $list = [];
+
         foreach ($exporters as $exporter => $formats) {
-            // prints the exporterentity, implodes the types and outputs them in a form
             $list[] = sprintf(
-                '%s (formats: %s)',
-                $exporter,
-                implode(', ', $formats)
+                '%s',
+                $exporter
             );
         }
 
         $io = new SymfonyStyle($input, $output);
         $io->listing($list);
         exit(0);
+    }
+
+    /**
+     * @param array $allItems
+     *
+     * @return array
+     */
+    private function prepareExport(array $allItems): array
+    {
+        $idsToExport = [];
+        foreach ($allItems as $item) {
+            /** @var ResourceInterface $item */
+            $idsToExport[] = $item->getId();
+        }
+
+        return $idsToExport;
+    }
+
+    /**
+     * @param string $name
+     * @param array $idsToExport
+     * @param string $exporter
+     */
+    private function export(string $name, array $idsToExport, string $exporter): void
+    {
+        /** @var ResourceExporterInterface $service */
+        $service = $this->exporterRegistry->get($name);
+        $service->export($idsToExport);
+        $itemsToExport = $service->getExportedData();
+
+        $mqItemWriter = new MqItemWriter(new RedisConnectionFactory());
+        $mqItemWriter->initQueue('sylius.export.queue.' . $exporter);
+        $mqItemWriter->write(json_decode($itemsToExport));
+    }
+
+    /**
+     * @param array $allItems
+     * @param string $file
+     * @param string $name
+     * @param OutputInterface $output
+     */
+    private function finishExport(array $allItems, string $file, string $name, OutputInterface $output): void
+    {
+        $message = sprintf(
+            "<info>Exported %d item(s) to '%s' via the %s exporter</info>",
+            count($allItems),
+            $file,
+            $name
+        );
+        $output->writeln($message);
     }
 }

--- a/src/Command/ImportDataCommand.php
+++ b/src/Command/ImportDataCommand.php
@@ -51,13 +51,13 @@ final class ImportDataCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $importer = $input->getArgument('importer');
         if (empty($importer)) {
             $this->listImporters($input, $output);
 
-            return 0;
+            return;
         }
 
         $format = $input->getOption('format');
@@ -72,7 +72,7 @@ final class ImportDataCommand extends Command
 
             $this->listImporters($input, $output);
 
-            return 1;
+            return;
         }
 
         $file = $input->getArgument('file');
@@ -112,7 +112,7 @@ final class ImportDataCommand extends Command
             ]
         );
 
-        return 0;
+        return;
     }
 
     /**

--- a/src/Command/ImportDataFromMessageQueueCommand.php
+++ b/src/Command/ImportDataFromMessageQueueCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfSylius\SyliusImportExportPlugin\Command;
+
+use Enqueue\Redis\RedisConnectionFactory;
+use FriendsOfSylius\SyliusImportExportPlugin\Exporter\MqItemReader;
+use FriendsOfSylius\SyliusImportExportPlugin\Importer\ImporterRegistry;
+use FriendsOfSylius\SyliusImportExportPlugin\Importer\SingleDataArrayImporterInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class ImportDataFromMessageQueueCommand extends Command
+{
+    /**
+     * @var ImporterRegistry
+     */
+    private $importerRegistry;
+
+    /**
+     * @param ImporterRegistry $importerRegistry
+     */
+    public function __construct(ImporterRegistry $importerRegistry)
+    {
+        $this->importerRegistry = $importerRegistry;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setName('sylius:import-from-message-queue')
+            ->setDescription('Import data from message queue.')
+            ->setDefinition([
+                new InputArgument('importer', InputArgument::OPTIONAL, 'The importer to use.'),
+            ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $importer = $input->getArgument('importer');
+
+        if (empty($importer)) {
+            $message = 'choose an importer';
+            $this->listImporters($input, $output, $message);
+        }
+
+        // only accepts the format of json as messages
+        $name = ImporterRegistry::buildServiceName($importer, 'json');
+
+        if (!$this->importerRegistry->has($name)) {
+            $message = sprintf(
+                "<error>There is no '%s' importer.</error>",
+                $name
+            );
+            $output->writeln($message);
+
+            $message = 'choose an importer and format';
+            $this->listImporters($input, $output, $message);
+        }
+
+        /** @var SingleDataArrayImporterInterface $service */
+        $service = $this->importerRegistry->get($name);
+
+        $this->getImporterJsonDataFromMessageQueue($importer, $service, $output);
+        $this->finishImport($name, $output);
+    }
+
+    /**
+     * @param string $name
+     * @param OutputInterface $output
+     */
+    private function finishImport(string $name, OutputInterface $output): void
+    {
+        $message = sprintf(
+            '<info>Imported from the message queue via the %s importer</info>',
+            $name
+        );
+        $output->writeln($message);
+    }
+
+    /**
+     * @param string $importer
+     * @param SingleDataArrayImporterInterface $service
+     * @param OutputInterface $output
+     */
+    private function getImporterJsonDataFromMessageQueue(string $importer, SingleDataArrayImporterInterface $service, OutputInterface $output): void
+    {
+        $mqItemReader = new MqItemReader(new RedisConnectionFactory(), $service);
+        $mqItemReader->initQueue('sylius.export.queue.' . $importer);
+        $mqItemReader->readAndImport();
+        $output->writeln('Imported: ' . $mqItemReader->getMessagesImportedCount());
+        $output->writeln('Skipped: ' . $mqItemReader->getMessagesSkippedCount());
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param string $message
+     */
+    private function listImporters(InputInterface $input, OutputInterface $output, string $message): void
+    {
+        $output->writeln($message);
+        $all = array_keys($this->importerRegistry->all());
+        $importers = [];
+        foreach ($all as $importer) {
+            $importer = explode('.', $importer);
+            $importers[$importer[0]][] = $importer[1];
+        }
+
+        $list = [];
+        $output->writeln('<info>Available importers:</info>');
+        foreach ($importers as $importer => $formats) {
+            $list[] = sprintf(
+                '%s',
+                $importer
+            );
+        }
+
+        $io = new SymfonyStyle($input, $output);
+        $io->listing($list);
+    }
+}

--- a/src/Exporter/ItemReaderInterface.php
+++ b/src/Exporter/ItemReaderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfSylius\SyliusImportExportPlugin\Exporter;
+
+interface ItemReaderInterface
+{
+    /**
+     * @param string $queueName
+     */
+    public function initQueue(string $queueName): void;
+
+    public function readAndImport(): void;
+
+    /**
+     * @return int
+     */
+    public function getMessagesImportedCount(): int;
+
+    /**
+     * @return int
+     */
+    public function getMessagesSkippedCount(): int;
+}

--- a/src/Exporter/ItemWriterInterface.php
+++ b/src/Exporter/ItemWriterInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfSylius\SyliusImportExportPlugin\Exporter;
+
+interface ItemWriterInterface
+{
+    /**
+     * @param string $queueName
+     */
+    public function initQueue(string $queueName): void;
+
+    /**
+     * @param array $items
+     */
+    public function write(array $items): void;
+}

--- a/src/Exporter/MqItemReader.php
+++ b/src/Exporter/MqItemReader.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfSylius\SyliusImportExportPlugin\Exporter;
+
+use Enqueue\Redis\RedisConnectionFactory;
+use Enqueue\Redis\RedisConsumer;
+use Enqueue\Redis\RedisMessage;
+use FriendsOfSylius\SyliusImportExportPlugin\Importer\SingleDataArrayImporterInterface;
+use Interop\Queue\PsrContext;
+use Interop\Queue\PsrQueue;
+
+class MqItemReader implements ItemReaderInterface
+{
+    /**
+     * @var PsrContext
+     */
+    private $redisContext;
+
+    /**
+     * @var PsrQueue
+     */
+    private $queue;
+
+    /**
+     * @var RedisConnectionFactory
+     */
+    private $redisConnectionFactory;
+
+    /**
+     * @var SingleDataArrayImporterInterface
+     */
+    private $service;
+
+    /**
+     * @var int
+     */
+    private $messagesImportedCount;
+
+    /**
+     * @var int
+     */
+    private $messagesSkippedCount;
+
+    /**
+     * MqItemReader constructor.
+     *
+     * @param RedisConnectionFactory $redisConnectionFactory
+     * @param SingleDataArrayImporterInterface $service
+     */
+    public function __construct(RedisConnectionFactory $redisConnectionFactory, SingleDataArrayImporterInterface $service)
+    {
+        $this->redisConnectionFactory = $redisConnectionFactory;
+        $this->service = $service;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initQueue(string $queueName): void
+    {
+        $this->redisContext = $this->redisConnectionFactory->createContext();
+        $this->queue = $this->redisContext->createQueue($queueName);
+        $this->messagesImportedCount = 0;
+        $this->messagesSkippedCount = 0;
+    }
+
+    public function readAndImport(): void
+    {
+        /** @var RedisConsumer $consumer */
+        $consumer = $this->redisContext->createConsumer($this->queue);
+
+        $dataTimestampArray = [];
+
+        /** @var RedisMessage $message */
+        while ($message = $consumer->receive()) {
+            $dataArrayToImport = (array) json_decode($message->getBody());
+            $dataTimestamp = strtotime($message->getHeader('recordedOn'));
+
+            if (array_key_exists($dataArrayToImport['Id'], $dataTimestampArray)) {
+                if ($dataTimestampArray[$dataArrayToImport['Id']] >= $dataTimestamp) {
+                    ++$this->messagesSkippedCount;
+
+                    continue;
+                }
+            }
+
+            $dataTimestampArray[$dataArrayToImport['Id']] = $dataTimestamp;
+            $this->service->importSingleDataArrayWithoutResult($dataArrayToImport);
+            ++$this->messagesImportedCount;
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getMessagesImportedCount(): int
+    {
+        return $this->messagesImportedCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMessagesSkippedCount(): int
+    {
+        return $this->messagesSkippedCount;
+    }
+}

--- a/src/Exporter/MqItemWriter.php
+++ b/src/Exporter/MqItemWriter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfSylius\SyliusImportExportPlugin\Exporter;
+
+use Enqueue\Redis\RedisConnectionFactory;
+use Interop\Queue\PsrConsumer;
+use Interop\Queue\PsrContext;
+use Interop\Queue\PsrQueue;
+
+class MqItemWriter implements ItemWriterInterface
+{
+    /**
+     * @var RedisConnectionFactory
+     */
+    private $redisConnectionFactory;
+
+    /**
+     * @var PsrContext
+     */
+    private $redisContext;
+
+    /**
+     * @var PsrQueue
+     */
+    private $queue;
+
+    /**
+     * @var PsrConsumer
+     */
+    private $consumer;
+
+    /**
+     * @param RedisConnectionFactory $redisConnectionFactory
+     */
+    public function __construct(RedisConnectionFactory $redisConnectionFactory)
+    {
+        $this->redisConnectionFactory = $redisConnectionFactory;
+    }
+
+    /**
+     * @param string $queueName
+     */
+    public function initQueue(string $queueName): void
+    {
+        $this->redisContext = $this->redisConnectionFactory->createContext();
+        $this->queue = $this->redisContext->createQueue($queueName);
+        $this->consumer = $this->redisContext->createConsumer($this->queue);
+    }
+
+    /**
+     * @param array $items
+     */
+    public function write(array $items): void
+    {
+        foreach ($items as $item) {
+            $message = $this->redisContext->createMessage(
+                json_encode($item),
+                [],
+                ['recordedOn' => (new \DateTime())->format('Y-m-d H:i:s')]
+            );
+            $this->redisContext->createProducer()->send($this->queue, $message);
+        }
+    }
+}

--- a/src/Exporter/ResourceExporter.php
+++ b/src/Exporter/ResourceExporter.php
@@ -81,6 +81,25 @@ class ResourceExporter implements ResourceExporterInterface
     }
 
     /**
+     * @param array $idsToExport
+     *
+     * @return array
+     */
+    public function exportData(array $idsToExport): array
+    {
+        $this->pluginPool->initPlugins($idsToExport);
+        $this->writer->write($this->resourceKeys);
+
+        $exportIdDataArray = [];
+
+        foreach ($idsToExport as $id) {
+            $exportIdDataArray[$id] = $this->getDataForId((string) $id);
+        }
+
+        return $exportIdDataArray;
+    }
+
+    /**
      * @param string $id
      */
     private function writeDataForId(string $id): void

--- a/src/Exporter/ResourceExporterInterface.php
+++ b/src/Exporter/ResourceExporterInterface.php
@@ -12,6 +12,13 @@ interface ResourceExporterInterface
     public function export(array $idsToExport): void;
 
     /**
+     * @param array $idsToExport
+     *
+     * @return array
+     */
+    public function exportData(array $idsToExport): array;
+
+    /**
      * @param string $filename
      */
     public function setExportFile(string $filename): void;

--- a/src/Importer/JsonResourceImporter.php
+++ b/src/Importer/JsonResourceImporter.php
@@ -7,7 +7,7 @@ namespace FriendsOfSylius\SyliusImportExportPlugin\Importer;
 use Doctrine\Common\Persistence\ObjectManager;
 use FriendsOfSylius\SyliusImportExportPlugin\Processor\ResourceProcessorInterface;
 
-final class JsonResourceImporter extends ResourceImporter
+final class JsonResourceImporter extends ResourceImporter implements SingleDataArrayImporterInterface
 {
     public function __construct(
         ObjectManager $objectManager,
@@ -43,5 +43,14 @@ final class JsonResourceImporter extends ResourceImporter
         $this->result->stop();
 
         return $this->result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function importSingleDataArrayWithoutResult(array $dataToImport): void
+    {
+        $this->resourceProcessor->process($dataToImport);
+        $this->objectManager->flush();
     }
 }

--- a/src/Importer/SingleDataArrayImporterInterface.php
+++ b/src/Importer/SingleDataArrayImporterInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfSylius\SyliusImportExportPlugin\Importer;
+
+interface SingleDataArrayImporterInterface extends ImporterInterface
+{
+    /**
+     * @param array $dataToImport
+     */
+    public function importSingleDataArrayWithoutResult(array $dataToImport): void;
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -62,6 +62,15 @@ services:
             - [ setContainer, ["@service_container"]]
         tags:
             - { name: 'console.command' }
+            
+    sylius.command.export_data_to_message_queue:
+        class: FriendsOfSylius\SyliusImportExportPlugin\Command\ExportDataToMessageQueueCommand
+        arguments:
+            - "@sylius.exporters_registry"
+        calls:
+            - [ setContainer, ["@service_container"]]
+        tags:
+            - { name: 'console.command' }
 
     # Plugins for Exporters
     sylius.exporter.plugin.resource.countries:

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -54,6 +54,13 @@ services:
         tags:
             - { name: 'console.command' }
 
+    sylius.command.import_data_data_from_message_queue:
+        class: FriendsOfSylius\SyliusImportExportPlugin\Command\ImportDataFromMessageQueueCommand
+        arguments:
+            - "@sylius.importers_registry"
+        tags:
+            - { name: 'console.command' }
+
     sylius.command.export_data:
         class: FriendsOfSylius\SyliusImportExportPlugin\Command\ExportDataCommand
         arguments:


### PR DESCRIPTION
fixes #8 

note this doesn't yet provide abstraction to use different MQ systems. atm only Redis is supported. (see https://github.com/FriendsOfSylius/SyliusImportExportPlugin/issues/127)

also note that the exit code handling in the commands should be updated in https://github.com/FriendsOfSylius/SyliusImportExportPlugin/pull/126 once this is merged