### PR TITLE
remove date check on import

### DIFF
--- a/src/Exporter/MqItemReader.php
+++ b/src/Exporter/MqItemReader.php
@@ -65,22 +65,10 @@ class MqItemReader implements ItemReaderInterface
         /** @var RedisConsumer $consumer */
         $consumer = $this->redisContext->createConsumer($this->queue);
 
-        $dataTimestampArray = [];
-
         /** @var RedisMessage $message */
         while ($message = $consumer->receive()) {
             $dataArrayToImport = (array) json_decode($message->getBody());
-            $dataTimestamp = strtotime($message->getHeader('recordedOn'));
 
-            if (array_key_exists($dataArrayToImport['Id'], $dataTimestampArray)) {
-                if ($dataTimestampArray[$dataArrayToImport['Id']] >= $dataTimestamp) {
-                    ++$this->messagesSkippedCount;
-
-                    continue;
-                }
-            }
-
-            $dataTimestampArray[$dataArrayToImport['Id']] = $dataTimestamp;
             $this->service->importSingleDataArrayWithoutResult($dataArrayToImport);
             ++$this->messagesImportedCount;
         }


### PR DESCRIPTION
removed it simply because this is makes data that wants to be imported need to have an `id` field.. it could potentially remade differently in another PR