### PR TITLE
Fix install with batch_size : 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ fos_sylius_import_export:
     importer:
       # set to false to not add an upload form to the entity overview pages
         web_ui:               true
-        # set to an integer value to flush the object manager in regular intervals
-        batch_size:           false
+        # set to an integer value bigger than 0 to flush the object manager in regular intervals
+        batch_size:           0
         # if incomplete rows (ie. missing required fields) should be considered failures
         fail_on_incomplete:   false
         # if to stop the import process in case of a failure

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ final class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('web_ui')->defaultTrue()->end()
-                        ->integerNode('batch_size')->defaultFalse()->end()
+                        ->integerNode('batch_size')->defaultValue(0)->end()
                         ->booleanNode('fail_on_incomplete')->defaultFalse()->end()
                         ->booleanNode('stop_on_failure')->defaultFalse()->end()
                     ->end()


### PR DESCRIPTION
With the config example in the README : `batch_size : false` we get this error :

```
In IntegerNode.php line 29:
                                                                                                        
  Invalid type for path "fos_sylius_import_export.importer.batch_size". Expected int, but got boolean.  
```                                                                                               

