### PR TITLE
Use field names instead of column names

### DIFF
--- a/spec/Exporter/Plugin/OrderResourcePluginSpec.php
+++ b/spec/Exporter/Plugin/OrderResourcePluginSpec.php
@@ -65,7 +65,7 @@ class OrderResourcePluginSpec extends ObjectBehavior
         );
 
         $entityManager->getClassMetadata(Argument::type('string'))->willReturn($classMetadata);
-        $classMetadata->getColumnNames()->willReturn(
+        $classMetadata->getFieldNames()->willReturn(
             [
                 'ShippingAddressId',
                 'BillingAddressId',

--- a/spec/Exporter/Plugin/ResourcePluginSpec.php
+++ b/spec/Exporter/Plugin/ResourcePluginSpec.php
@@ -59,7 +59,7 @@ class ResourcePluginSpec extends ObjectBehavior
         );
 
         $entityManager->getClassMetadata(Argument::type('string'))->willReturn($classMetadata);
-        $classMetadata->getColumnNames()->willReturn(
+        $classMetadata->getFieldNames()->willReturn(
             [
                 'Code',
                 'Name',

--- a/src/Exporter/Plugin/ResourcePlugin.php
+++ b/src/Exporter/Plugin/ResourcePlugin.php
@@ -118,7 +118,7 @@ class ResourcePlugin implements PluginInterface
     {
         $fields = $this->entityManager->getClassMetadata(\get_class($resource));
 
-        foreach ($fields->getColumnNames() as $index => $field) {
+        foreach ($fields->getFieldNames() as $index => $field) {
             $this->fieldNames[$index] = ucfirst($field);
 
             if (!$this->propertyAccessor->isReadable($resource, $field)) {


### PR DESCRIPTION
We came across an issue caused by using column names instead of field names while exporting taxons. The taxon has the `right` field, which is mapped as `tree_right` column. This makes the property accessor trying to get `treeRight` property or call `getTreeRight` method which does not exist and the export crashes.