### PR TITLE
fix ChannelInterface and ChannelPricingInterface types

### DIFF
--- a/src/Exporter/Plugin/ProductResourcePlugin.php
+++ b/src/Exporter/Plugin/ProductResourcePlugin.php
@@ -7,6 +7,7 @@ namespace FriendsOfSylius\SyliusImportExportPlugin\Exporter\Plugin;
 use Doctrine\ORM\EntityManagerInterface;
 use FriendsOfSylius\SyliusImportExportPlugin\Service\ImageTypesProvider;
 use Sylius\Component\Attribute\Model\AttributeValueInterface;
+use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ImageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -130,10 +131,15 @@ final class ProductResourcePlugin extends ResourcePlugin
         /** @var \Sylius\Component\Core\Model\ChannelInterface[] $channel */
         $channels = $resource->getChannels();
         foreach ($channels as $channel) {
+            /** @var ChannelPricingInterface|null $channelPricing */
             $channelPricing = $this->channelPricingRepository->findOneBy([
                 'channelCode' => $channel->getCode(),
                 'productVariant' => $productVariant,
             ]);
+
+            if (null === $channelPricing) {
+                continue;
+            }
 
             $this->addDataForResource($resource, 'Price', $channelPricing->getPrice());
         }

--- a/src/Processor/ProductProcessor.php
+++ b/src/Processor/ProductProcessor.php
@@ -12,6 +12,7 @@ use FriendsOfSylius\SyliusImportExportPlugin\Service\ImageTypesProvider;
 use FriendsOfSylius\SyliusImportExportPlugin\Service\ImageTypesProviderInterface;
 use Sylius\Bundle\CoreBundle\Doctrine\ORM\ProductTaxonRepository;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductImageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -259,6 +260,7 @@ final class ProductProcessor implements ResourceProcessorInterface
 
         $channels = \explode('|', $data['Channels']);
         foreach ($channels as $channelCode) {
+            /** @var ChannelPricingInterface|null $channelPricing */
             $channelPricing = $this->channelPricingRepository->findOneBy([
                 'channelCode' => $channelCode,
                 'productVariant' => $productVariant,
@@ -301,6 +303,7 @@ final class ProductProcessor implements ResourceProcessorInterface
     {
         $channels = \explode('|', $data['Channels']);
         foreach ($channels as $channelCode) {
+            /** @var ChannelInterface|null $channel */
             $channel = $this->channelRepository->findOneBy(['code' => $channelCode]);
             if ($channel === null) {
                 continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?   | no
| Fixed tickets | 

Fixes for PHPStan issues :

```
 ------ ----------------------------------------------- 
  Line   Exporter/Plugin/ProductResourcePlugin.php      
 ------ ----------------------------------------------- 
  138    Cannot call method getPrice() on object|null.  
 ------ ----------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Processor/ProductProcessor.php                                                                                                                                              
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  274    Call to an undefined method object::setPrice().                                                                                                                             
  275    Call to an undefined method object::setOriginalPrice().                                                                                                                     
  308    Parameter #1 $channel of method Sylius\Component\Channel\Model\ChannelsAwareInterface::addChannel() expects Sylius\Component\Channel\Model\ChannelInterface, object given.  
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
```
