### PR TITLE
Add content type to header

### DIFF
--- a/src/Controller/ExportDataController.php
+++ b/src/Controller/ExportDataController.php
@@ -79,6 +79,9 @@ final class ExportDataController
             ResponseHeaderBag::DISPOSITION_ATTACHMENT,
             $outputFilename
         );
+        
+        
+        $response->headers->set('Content-Type', 'application/' . $format);
         $response->headers->set('Content-Disposition', $disposition);
 
         return $response;

--- a/src/Controller/ExportDataController.php
+++ b/src/Controller/ExportDataController.php
@@ -79,8 +79,7 @@ final class ExportDataController
             ResponseHeaderBag::DISPOSITION_ATTACHMENT,
             $outputFilename
         );
-        
-        
+
         $response->headers->set('Content-Type', 'application/' . $format);
         $response->headers->set('Content-Disposition', $disposition);
 


### PR DESCRIPTION
Add the content type to header for correct file format download

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed tickets | #165  

Fix the bad .html extension when download exported file from Web UI
