### PR TITLE
Support for Symfony 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.2",
         "sylius/sylius": "^1.4",
         "portphp/portphp": "^1.2",
-        "symfony/stopwatch": "^3.3 | ^4.1",
+        "symfony/stopwatch": "^3.3 | ^4.1 | ^5.0",
         "queue-interop/queue-interop": "^0.6.2|^0.7|^0.8"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?   | no
| Fixed tickets | #237 

Update the dependency of the Symfony Stopwatch component (thanks to @andychan94) to add support for Symfony 4.4.
