### PR TITLE
Stopwatch bump ver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "friendsofsylius/sylius-import-export-plugin",
+    "name": "mylittleparis/sylius-import-export-plugin",
     "type": "sylius-plugin",
     "description": "import / export plugin for Sylius.",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sylius/sylius-import-export-plugin",
+    "name": "friendsofsylius/sylius-import-export-plugin",
     "type": "sylius-plugin",
     "description": "import / export plugin for Sylius.",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mylittleparis/sylius-import-export-plugin",
+    "name": "sylius/sylius-import-export-plugin",
     "type": "sylius-plugin",
     "description": "import / export plugin for Sylius.",
     "license": "MIT",
@@ -7,7 +7,7 @@
         "php": "^7.2",
         "sylius/sylius": "^1.4",
         "portphp/portphp": "^1.2",
-        "symfony/stopwatch": "^3.3 | ^4.1 | ^5.0",
+        "symfony/stopwatch": "^4.4 || ^5.2",
         "queue-interop/queue-interop": "^0.6.2|^0.7|^0.8"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed tickets | #241  <!-- #-prefixed issue number(s), if any -->

Bumped up version dependency of stopwatch to prevent `composer require sylius/sylius-import-export-plugin` breaking because of stopwatch's version lock when using Sylius 1.9 (and therefore Symfony 5.2+)
<!--

-->
