### PR TITLE
Use Sylius parameter for product image model

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -355,7 +355,7 @@ services:
     sylius.class_metadata.product_image:
         class: Doctrine\ORM\Mapping\ClassMetadata
         factory:   ['@doctrine.orm.default_entity_manager' , 'getClassMetadata']
-        arguments: ['Sylius\Component\Core\Model\ProductImage']
+        arguments: ['%sylius.model.product_image.class%']
 
     sylius.repository.product_image:
         class: FriendsOfSylius\SyliusImportExportPlugin\Repository\ProductImageImageRepository


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed tickets | #253

Hard-coding the ProductImage model class breaks default setups where the entity is actually `App\Entity\Product\ProductImage`.
The default in Sylius apparently is to always use parameters where models are involved.