### PR TITLE
Fix: deprecated treebuilder initialisation for symfony 4.2+

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,9 +14,13 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder('');
-        $rootNode = $treeBuilder->getRootNode('fos_sylius_import_export');
-
+        if (\method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('fos_sylius_import_export');
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('fos_sylius_import_export');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Bug fix? yes
New feature? no
BC breaks? no
Fixed tickets -

Not passing the root node name to TreeBuilder was deprecated in Symfony 4.2.
https://symfony.com/doc/4.4/components/config/definition.html