### PR TITLE
extend ProductProcessor to import product options and variants

### DIFF
--- a/src/Processor/ProductProcessor.php
+++ b/src/Processor/ProductProcessor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FriendsOfSylius\SyliusImportExportPlugin\Processor;
 
 use Doctrine\ORM\EntityManagerInterface;
+use FriendsOfSylius\SyliusImportExportPlugin\Exception\ImporterException;
 use FriendsOfSylius\SyliusImportExportPlugin\Importer\Transformer\TransformerPoolInterface;
 use FriendsOfSylius\SyliusImportExportPlugin\Repository\ProductImageRepositoryInterface;
 use FriendsOfSylius\SyliusImportExportPlugin\Service\AttributeCodesProviderInterface;
@@ -24,6 +25,7 @@ use Sylius\Component\Product\Factory\ProductFactoryInterface;
 use Sylius\Component\Product\Generator\SlugGeneratorInterface;
 use Sylius\Component\Product\Model\ProductAttribute;
 use Sylius\Component\Product\Model\ProductAttributeValueInterface;
+use Sylius\Component\Product\Model\ProductOptionValueInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Taxonomy\Factory\TaxonFactoryInterface;
@@ -32,6 +34,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 final class ProductProcessor implements ResourceProcessorInterface
 {
+    private const COLUMN_PRODUCT_OPTION_PREFIX = "Product_Option_";
+
     /** @var RepositoryInterface */
     private $channelPricingRepository;
     /** @var FactoryInterface */
@@ -82,6 +86,10 @@ final class ProductProcessor implements ResourceProcessorInterface
     private $productVariantFactory;
     /** @var RepositoryInterface */
     private $productVariantRepository;
+    /** @var RepositoryInterface */
+    private $productOptionRepository;
+    /** @var RepositoryInterface */
+    private $productOptionValueRepository;
 
     public function __construct(
         ProductFactoryInterface $productFactory,
@@ -101,13 +109,16 @@ final class ProductProcessor implements ResourceProcessorInterface
         ProductTaxonRepository $productTaxonRepository,
         ProductImageRepositoryInterface $productImageRepository,
         RepositoryInterface $productVariantRepository,
+        RepositoryInterface $productOptionRepository,
+        RepositoryInterface $productOptionValueRepository,
         RepositoryInterface $channelPricingRepository,
         ImageTypesProviderInterface $imageTypesProvider,
         SlugGeneratorInterface $slugGenerator,
         ?TransformerPoolInterface $transformerPool,
         EntityManagerInterface $manager,
         array $headerKeys
-    ) {
+    )
+    {
         $this->resourceProductFactory = $productFactory;
         $this->resourceTaxonFactory = $taxonFactory;
         $this->productRepository = $productRepository;
@@ -129,6 +140,8 @@ final class ProductProcessor implements ResourceProcessorInterface
         $this->imageTypesProvider = $imageTypesProvider;
         $this->productVariantFactory = $productVariantFactory;
         $this->productVariantRepository = $productVariantRepository;
+        $this->productOptionRepository = $productOptionRepository;
+        $this->productOptionValueRepository = $productOptionValueRepository;
         $this->channelPricingFactory = $channelPricingFactory;
         $this->channelPricingRepository = $channelPricingRepository;
     }
@@ -145,67 +158,198 @@ final class ProductProcessor implements ResourceProcessorInterface
         $this->headerKeys = \array_merge($this->headerKeys, $this->imageCode);
         $this->metadataValidator->validateHeaders($this->headerKeys, $data);
 
-        $product = $this->getProduct($data['Code']);
+        /** @var ProductInterface $product */
+        $product = $this->productRepository->findOneByCode($data['Code']);
 
-        $this->setDetails($product, $data);
-        $this->setVariant($product, $data);
-        $this->setAttributesData($product, $data);
-        $this->setMainTaxon($product, $data);
-        $this->setTaxons($product, $data);
-        $this->setChannel($product, $data);
-        $this->setImage($product, $data);
+        if (null === $product) {
+            $product = $this->resourceProductFactory->createNew();
+            $product->setCode($data['Code']);
+
+            $this->setDetails($product, $data);
+            $this->setOptions($product, $data);
+            $this->setVariant($product, $data);
+            $this->setAttributesData($product, $data);
+            $this->setMainTaxon($product, $data);
+            $this->setTaxons($product, $data);
+            $this->setChannel($product, $data);
+            $this->setImage($product, $data);
+        } else {
+            $this->setOptions($product, $data);
+            $this->setVariant($product, $data);
+        }
 
         $this->productRepository->add($product);
     }
 
-    private function getProduct(string $code): ProductInterface
+    private function setDetails(ProductInterface $product, array $data): void
     {
-        /** @var ProductInterface|null $product */
-        $product = $this->productRepository->findOneBy(['code' => $code]);
-        if (null === $product) {
-            /** @var ProductInterface $product */
-            $product = $this->resourceProductFactory->createNew();
-            $product->setCode($code);
-        }
+        $product->setCurrentLocale($data['Locale']);
+        $product->setFallbackLocale($data['Locale']);
 
-        return $product;
+        $product->setName(substr($data['Name'], 0, 255));
+        $product->setEnabled((bool)$data['Enabled']);
+        $product->setDescription($data['Description']);
+        $product->setShortDescription(substr($data['Short_description'], 0, 255));
+        $product->setMetaDescription(substr($data['Meta_description'], 0, 255));
+        $product->setMetaKeywords(substr($data['Meta_keywords'], 0, 255));
+        $product->setSlug($product->getSlug() ?: $this->slugGenerator->generate($product->getName()));
     }
 
-    private function getProductVariant(string $code): ProductVariantInterface
+    private function setOptions(ProductInterface $product, array $data)
     {
-        /** @var ProductVariantInterface|null $productVariant */
-        $productVariant = $this->productVariantRepository->findOneBy(['code' => $code]);
-        if ($productVariant === null) {
-            /** @var ProductVariantInterface $productVariant */
-            $productVariant = $this->productVariantFactory->createNew();
-            $productVariant->setCode($code);
+        $productOptionCodes = $this->getProductOptionCodesFromData($data);
+
+        foreach ($productOptionCodes as $productOptionCode) {
+            $productOptionItem = $this->productOptionRepository->findOneBy(['code' => $productOptionCode]);
+            $product->addOption($productOptionItem);
+        }
+    }
+
+    private function getProductOptionCodesFromData(array $data): array
+    {
+        $productOptionColumns = array_keys($this->getNonEmptyProductOptionColumnsFromData($data));
+        $productOptionCodes = array_map(
+            function (string $productOptionColumnName) {
+                return substr($productOptionColumnName, strlen(self::COLUMN_PRODUCT_OPTION_PREFIX));
+            },
+            $productOptionColumns
+        );
+
+        return $productOptionCodes;
+    }
+
+    private function getNonEmptyProductOptionColumnsFromData(array $data): array
+    {
+        return array_filter(
+            $data,
+            function ($value, $key) {
+                return !empty($value) && strpos($key, self::COLUMN_PRODUCT_OPTION_PREFIX) === 0;
+            },
+            ARRAY_FILTER_USE_BOTH
+        );
+    }
+
+    private function setVariant(ProductInterface $product, array $data): void
+    {
+        $productVariant = $this->getProductVariant($product, $data);
+        $productVariant->setCurrentLocale($this->getVariantLocale($data, $product));
+        $productVariant->setName($this->generateVariantName($data, $product->getName()));
+
+        $channels = \explode('|', $data['Channels']);
+        foreach ($channels as $channelCode) {
+            /** @var ChannelPricingInterface|null $channelPricing */
+            $channelPricing = $this->channelPricingRepository->findOneBy([
+                'channelCode' => $channelCode,
+                'productVariant' => $productVariant,
+            ]);
+
+            if (null === $channelPricing) {
+                /** @var ChannelPricingInterface $channelPricing */
+                $channelPricing = $this->channelPricingFactory->createNew();
+                $channelPricing->setChannelCode($channelCode);
+                $productVariant->addChannelPricing($channelPricing);
+            }
+
+            $channelPricing->setPrice((int)$data['Price']);
+            $channelPricing->setOriginalPrice((int)$data['Price']);
+        }
+
+        $product->addVariant($productVariant);
+    }
+
+    private function getProductVariant(ProductInterface $product, array $data): ProductVariantInterface
+    {
+        $productVariant = null;
+        $productVariants = $product->getVariants();
+        $productOptionValueListFromData = $this->getProductOptionValueListFromData($data);
+
+        if ($productVariants->isEmpty()) {
+            $productVariant = $this->createNewProductVariant($product->getCode(), 1, $productOptionValueListFromData);
+        } else {
+            // look for the corresponding Product variant with the given option values
+            $productVariantFound = false;
+
+            /** @var ProductVariantInterface $productVariantItem */
+            foreach ($productVariants as $productVariantItem) {
+                $productVariantOptionValueCheckResult = array_map(
+                    function (ProductOptionValueInterface $optionValue) use ($productVariantItem) {
+                        return $productVariantItem->hasOptionValue($optionValue);
+                    },
+                    $productOptionValueListFromData
+                );
+
+                $productVariantFound = array_product($productVariantOptionValueCheckResult);
+                if ($productVariantFound) {
+                    $productVariant = $productVariantItem;
+                    break;
+                }
+            }
+
+            if (!$productVariantFound) {
+                $nextVariantSuffixNumber = count($productVariants) + 1;
+                $productVariant = $this->createNewProductVariant($product->getCode(), $nextVariantSuffixNumber, $productOptionValueListFromData);
+            }
         }
 
         return $productVariant;
     }
 
-    private function setMainTaxon(ProductInterface $product, array $data): void
+    private function getProductOptionValueListFromData(array $data): array
     {
-        /** @var Taxon|null $taxon */
-        $taxon = $this->taxonRepository->findOneBy(['code' => $data['Main_taxon']]);
-        if ($taxon === null) {
-            return;
-        }
+        $productOptionValues = array_values($this->getNonEmptyProductOptionColumnsFromData($data));
+        $productOptionValueList = array_map(
+            function (string $optionValueCode) use ($data) {
+                /** @var ProductOptionValueInterface $productOptionValueItem */
+                $productOptionValueItem = $this->productOptionValueRepository->findOneBy(['code' => $optionValueCode]);
 
-        /** @var ProductInterface $product */
-        $product->setMainTaxon($taxon);
+                if ($productOptionValueItem === null) {
+                    throw new ImporterException('Product Option Value does not exist, please add it to your system: ' .
+                        $optionValueCode . ' for Product: ' . $data['Name']);
+                }
 
-        $this->addTaxonToProduct($product, $data['Main_taxon']);
+                return $productOptionValueItem;
+            },
+            $productOptionValues
+        );
+
+        return $productOptionValueList;
     }
 
-    private function setTaxons(ProductInterface $product, array $data): void
+    private function createNewProductVariant(string $productCode,
+                                             int $variantSuffixNumber,
+                                             array $productOptionValueList): ProductVariantInterface
     {
-        $taxonCodes = \explode('|', $data['Taxons']);
-        foreach ($taxonCodes as $taxonCode) {
-            if ($taxonCode !== $data['Main_taxon']) {
-                $this->addTaxonToProduct($product, $taxonCode);
-            }
+        /** @var ProductVariantInterface $productVariant */
+        $productVariant = $this->productVariantFactory->createNew();
+        $productVariant->setCode($this->generateVariantCode($productCode, $variantSuffixNumber));
+
+        /** @var ProductOptionValueInterface $productOptionValue */
+        foreach ($productOptionValueList as $productOptionValue) {
+            $productVariant->addOptionValue($productOptionValue);
         }
+
+        return $productVariant;
+    }
+
+    private function generateVariantCode(string $productCode, int $suffixNumber): string
+    {
+        return sprintf("%s-%02d", $productCode, $suffixNumber);
+    }
+
+    private function getVariantLocale(array $data, ProductInterface $product): string
+    {
+        return $data['Locale'] ?: $product->getTranslation()->getLocale();
+    }
+
+    private function generateVariantName(array $data, $fallbackName): string
+    {
+        $variantName = substr($data['Name'], 0, 255);
+
+        if (empty($variantName) && empty($fallbackName)) {
+            throw new ImporterException('Missing name for Product variant with code: ' . $data['Code']);
+        }
+
+        return $variantName ?: $fallbackName;
     }
 
     private function setAttributesData(ProductInterface $product, array $data): void
@@ -238,48 +382,6 @@ final class ProductProcessor implements ResourceProcessorInterface
         }
     }
 
-    private function setDetails(ProductInterface $product, array $data): void
-    {
-        $product->setCurrentLocale($data['Locale']);
-        $product->setFallbackLocale($data['Locale']);
-
-        $product->setName(substr($data['Name'], 0, 255));
-        $product->setEnabled((bool) $data['Enabled']);
-        $product->setDescription($data['Description']);
-        $product->setShortDescription(substr($data['Short_description'], 0, 255));
-        $product->setMetaDescription(substr($data['Meta_description'], 0, 255));
-        $product->setMetaKeywords(substr($data['Meta_keywords'], 0, 255));
-        $product->setSlug($product->getSlug() ?: $this->slugGenerator->generate($product->getName()));
-    }
-
-    private function setVariant(ProductInterface $product, array $data): void
-    {
-        $productVariant = $this->getProductVariant($product->getCode());
-        $productVariant->setCurrentLocale($data['Locale']);
-        $productVariant->setName(substr($data['Name'], 0, 255));
-
-        $channels = \explode('|', $data['Channels']);
-        foreach ($channels as $channelCode) {
-            /** @var ChannelPricingInterface|null $channelPricing */
-            $channelPricing = $this->channelPricingRepository->findOneBy([
-                'channelCode' => $channelCode,
-                'productVariant' => $productVariant,
-            ]);
-
-            if (null === $channelPricing) {
-                /** @var ChannelPricingInterface $channelPricing */
-                $channelPricing = $this->channelPricingFactory->createNew();
-                $channelPricing->setChannelCode($channelCode);
-                $productVariant->addChannelPricing($channelPricing);
-            }
-
-            $channelPricing->setPrice((int) $data['Price']);
-            $channelPricing->setOriginalPrice((int) $data['Price']);
-        }
-
-        $product->addVariant($productVariant);
-    }
-
     private function setAttributeValue(ProductInterface $product, array $data, string $attrCode): void
     {
         /** @var ProductAttribute $productAttr */
@@ -299,17 +401,18 @@ final class ProductProcessor implements ResourceProcessorInterface
         $this->manager->persist($attr);
     }
 
-    private function setChannel(ProductInterface $product, array $data): void
+    private function setMainTaxon(ProductInterface $product, array $data): void
     {
-        $channels = \explode('|', $data['Channels']);
-        foreach ($channels as $channelCode) {
-            /** @var ChannelInterface|null $channel */
-            $channel = $this->channelRepository->findOneBy(['code' => $channelCode]);
-            if ($channel === null) {
-                continue;
-            }
-            $product->addChannel($channel);
+        /** @var Taxon|null $taxon */
+        $taxon = $this->taxonRepository->findOneBy(['code' => $data['Main_taxon']]);
+        if ($taxon === null) {
+            return;
         }
+
+        /** @var ProductInterface $product */
+        $product->setMainTaxon($taxon);
+
+        $this->addTaxonToProduct($product, $data['Main_taxon']);
     }
 
     private function addTaxonToProduct(ProductInterface $product, string $taxonCode): void
@@ -333,6 +436,29 @@ final class ProductProcessor implements ResourceProcessorInterface
         $productTaxon = $this->productTaxonFactory->createNew();
         $productTaxon->setTaxon($taxon);
         $product->addProductTaxon($productTaxon);
+    }
+
+    private function setTaxons(ProductInterface $product, array $data): void
+    {
+        $taxonCodes = \explode('|', $data['Taxons']);
+        foreach ($taxonCodes as $taxonCode) {
+            if ($taxonCode !== $data['Main_taxon']) {
+                $this->addTaxonToProduct($product, $taxonCode);
+            }
+        }
+    }
+
+    private function setChannel(ProductInterface $product, array $data): void
+    {
+        $channels = \explode('|', $data['Channels']);
+        foreach ($channels as $channelCode) {
+            /** @var ChannelInterface|null $channel */
+            $channel = $this->channelRepository->findOneBy(['code' => $channelCode]);
+            if ($channel === null) {
+                continue;
+            }
+            $product->addChannel($channel);
+        }
     }
 
     private function setImage(ProductInterface $product, array $data): void

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -345,6 +345,8 @@ services:
             - '@sylius.repository.product_taxon'
             - '@sylius.repository.product_image'
             - '@sylius.repository.product_variant'
+            - '@sylius.repository.product_option'
+            - '@sylius.repository.product_option_value'
             - '@sylius.repository.channel_pricing'
             - '@sylius.service.product_image_code'
             - "@sylius.generator.slug"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?   | no
| Fixed tickets | #200

Add support for importing Product variants with their related Product options. 

Current solution notes:

- Product options need to be prefixed in the csv file with "Product_Option_<OPTION_CODE_NAME>"
- The Product options need to exist already in Sylius
- To create different Product variants, you set the same "Code" for each product row, so the relationship between the Product and Product variants can be managed without any additional "Parent Code" column for example.

Still open todo:

- Tests
- Export logic
- Docs update