### PR TITLE
Make service config a bit more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ admin overview panel using the event hook system, ie. `admin/tax-categories/`.
 
 #### Notes
   
-  - Replace `app.foo` with the name of the resource (under `sylius_resource` config) you want to implement in the following examples.
+  - Replace `app` and `foo` with the name of the resource (under `sylius_resource` config) you want to implement in the following examples.
   - Replace `bar` with the name of the format you want to implement in the following examples (csv, json, ...).
   - Note it is of course also possible to implement a dedicated importer for `app.foo` resource and format `bar`,
     in case a generic type implementation is not possible.
@@ -177,7 +177,7 @@ sylius.importer.foo.bar:
         - "@sylius.processor.foo"
         - "@sylius.importer.result"
     tags:
-        - { name: sylius.importer, type: app.foo, format: csv }
+        - { name: sylius.importer, type: foo, domain: app, format: csv }
 ```
   
 ##### Alternatively implement a custom ResourceImporter _FooImporter_
@@ -199,7 +199,7 @@ sylius.importer.foo.bar:
       - "@sylius.processor.foo"
       - "@sylius.importer.result"
   tags:
-      - { name: sylius.importer, type: app.foo, format: bar }
+      - { name: sylius.importer, type: foo, domain: app, format: bar }
 ```
 
 #### Adding a ResourceProcessor


### PR DESCRIPTION
Added option to use 'domain' in service config tag so instead of type taking the value "app.foo" you will use "type: foo" and "domain: app"
This fixes the selection of export format in the admin interface.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed tickets | #249 

<!--
- Replace this comment by a description of what your PR is solving.
-->
