### PR TITLE
Fix twig deprecations

### DIFF
--- a/spec/Controller/ImportDataControllerSpec.php
+++ b/spec/Controller/ImportDataControllerSpec.php
@@ -9,6 +9,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Registry\ServiceRegistryInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Twig\Environment;
 
 class ImportDataControllerSpec extends ObjectBehavior
 {
@@ -16,7 +17,7 @@ class ImportDataControllerSpec extends ObjectBehavior
         ServiceRegistryInterface $registry,
         FlashBagInterface $flashBag,
         FormFactoryInterface $formFactory,
-        \Twig_Environment $twig
+        Environment $twig
     ) {
         $this->beConstructedWith(
             $registry,

--- a/src/Controller/ImportDataController.php
+++ b/src/Controller/ImportDataController.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Twig\Environment;
 
 final class ImportDataController
 {
@@ -29,14 +30,14 @@ final class ImportDataController
     /** @var FormFactoryInterface */
     private $formFactory;
 
-    /** @var \Twig_Environment */
+    /** @var Environment */
     private $twig;
 
     public function __construct(
         ServiceRegistryInterface $registry,
         FlashBagInterface $flashBag,
         FormFactoryInterface $formFactory,
-        \Twig_Environment $twig
+        Environment $twig
     ) {
         $this->registry = $registry;
         $this->formFactory = $formFactory;

--- a/src/Resources/views/Form/theme.html.twig
+++ b/src/Resources/views/Form/theme.html.twig
@@ -1,7 +1,7 @@
 {% extends '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block _import_import_data_row %}
-    {% spaceless %}
+    {% apply spaceless %}
         <label for="{{ form.vars.id }}" class="ui icon labeled button">
             <i class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}
         </label>
@@ -11,5 +11,5 @@
         <div class="ui element">
             {{- form_errors(form) -}}
         </div>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}


### PR DESCRIPTION
Since Twig 2.7 these feature has been deprecated and now can safely be used as minimal dependency is 2.11 for this package.