### PR TITLE
Conflict with api platform prevent upgrades

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,6 @@
         "predis/predis": "^1.1"
     },
     "conflict": {
-        "api-platform/core": ">= 2.7.0",
         "symfony/symfony": "4.1.8",
         "symfony/browser-kit": "4.1.8",
         "symfony/dependency-injection": "4.1.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?   | no
| Fixed tickets | https://github.com/FriendsOfSylius/SyliusImportExportPlugin/issues/287

I'm not sure why there's a conflict with API platform but it's a problem with API 1.12 and in the future, 1.13.
2.6.* works but 2.7.* should be allowed to prepare future upgrades.

Edit : damn that's my own mistake :D 