### PR TITLE
allow non scalar values for criteria

### DIFF
--- a/src/Listener/ExportButtonGridListener.php
+++ b/src/Listener/ExportButtonGridListener.php
@@ -86,7 +86,7 @@ final class ExportButtonGridListener
         $currentRequest = $this->requestStack->getCurrentRequest();
         if ($currentRequest) {
             // @TODO Find way to validate the list of criteria injected
-            $parameters['criteria'] = $currentRequest->query->get('criteria');
+            $parameters['criteria'] = $currentRequest->get('criteria');
         }
 
         $resource = $this->resource;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed tickets | none
This change allows non scalar values to be used through the criteria : filters passed bu Sylius Grid.

This is needed for most filters, including plain text search : ?criteria[search][type]=contains&criteria[search][value]=test
