### PR TITLE
Use proper Twig controller render statement

### DIFF
--- a/src/Resources/views/Crud/import.html.twig
+++ b/src/Resources/views/Crud/import.html.twig
@@ -1,4 +1,4 @@
 {{ render(controller(
-    'sylius.controller.import_data:importFormAction',
+    'sylius.controller.import_data::importFormAction',
     {'resource': block.settings.resources.metadata.name}
 )) }}

--- a/src/Resources/views/Taxonomy/import.html.twig
+++ b/src/Resources/views/Taxonomy/import.html.twig
@@ -1,1 +1,1 @@
-{{ render(controller('sylius.controller.import_data:importFormAction', {'resource': 'taxonomy'})) }}
+{{ render(controller('sylius.controller.import_data::importFormAction', {'resource': 'taxonomy'})) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?   | no
| Fixed tickets | #290

Use the proper Twig render `controller(...)` statement (using double semicolon instead of only one semicolon for defining the controller action method).
